### PR TITLE
fix: sign out

### DIFF
--- a/components/header.tsx
+++ b/components/header.tsx
@@ -51,10 +51,15 @@ export function Header() {
     setIsMobileMenuOpen(!isMobileMenuOpen)
   }
 
-  const handleSignOut = () => {
-    signOut()
-    toast.success("Successfully signed out")
-    router.push("/")
+  const handleSignOut = async () => {
+    try {
+      await signOut()
+      toast.success("Successfully signed out")
+      router.push("/")
+    } catch (error) {
+      console.error("Sign out error:", error)
+      toast.error("Error signing out")
+    }
   }
 
   // Mock data for notifications and messages
@@ -844,9 +849,9 @@ export function Header() {
                     <Button
                       variant="ghost"
                       className="w-full justify-start text-red-600 hover:text-red-600 hover:bg-red-50"
-                      onClick={() => {
+                      onClick={async () => {
                         setIsMobileMenuOpen(false)
-                        handleSignOut()
+                        await handleSignOut()
                       }}
                     >
                       <LogOut className="mr-2 h-4 w-4" />

--- a/components/header/index.tsx
+++ b/components/header/index.tsx
@@ -43,10 +43,15 @@ export function Header() {
   /**
    * Handle user sign out
    */
-  const handleSignOut = () => {
-    signOut()
-    toast.success("Successfully signed out")
-    router.push("/")
+  const handleSignOut = async () => {
+    try {
+      await signOut()
+      toast.success("Successfully signed out")
+      router.push("/")
+    } catch (error) {
+      console.error("Sign out error:", error)
+      toast.error("Error signing out")
+    }
   }
 
   return (

--- a/components/header/mobile-menu.tsx
+++ b/components/header/mobile-menu.tsx
@@ -15,7 +15,7 @@ interface MobileMenuProps {
   onLinkClick: () => void
   unreadMessages: number
   unreadNotifications: number
-  onSignOut: () => void
+  onSignOut: () => Promise<void>
   userProfile?: {
     firstName?: string
     lastName?: string
@@ -135,9 +135,9 @@ export function MobileMenu({
               <Button
                 variant="ghost"
                 className="w-full justify-start text-red-600 hover:text-red-600 hover:bg-red-50"
-                onClick={() => {
+                onClick={async () => {
                   onLinkClick()
-                  onSignOut()
+                  await onSignOut()
                 }}
               >
                 <LogOut className="mr-2 h-4 w-4" />

--- a/components/header/user-actions.tsx
+++ b/components/header/user-actions.tsx
@@ -12,7 +12,7 @@ interface UserActionsProps {
   userRole?: UserRole
   unreadMessages: number
   unreadNotifications: number
-  onSignOut: () => void
+  onSignOut: () => Promise<void>
   userProfile?: {
     firstName?: string
     lastName?: string
@@ -96,7 +96,7 @@ export function UserActions({
           variant="ghost"
           size="icon"
           className="relative hover:bg-gray-100 transition-colors text-red-600 hover:text-red-700"
-          onClick={onSignOut}
+          onClick={async () => await onSignOut()}
           aria-label="Sign Out"
         >
           <LogOut className="w-5 h-5" />

--- a/store/auth-store.ts
+++ b/store/auth-store.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand"
 import { persist } from "zustand/middleware"
 import type { User } from "@/lib/validations/auth"
+import { authService } from "@/lib/auth-service"
 
 interface AuthState {
   user: User | null
@@ -10,7 +11,7 @@ interface AuthState {
   setUser: (user: User | null) => void
   setLoading: (loading: boolean) => void
   setError: (error: string | null) => void
-  signOut: () => void
+  signOut: () => Promise<void>
   clearError: () => void
   hasRole: (role: string) => boolean
   hasPermission: (permission: string) => boolean
@@ -36,12 +37,20 @@ export const useAuthStore = create<AuthState>()(
 
       setError: (error) => set({ error }),
 
-      signOut: () => {
-        set({
-          user: null,
-          isAuthenticated: false,
-          error: null,
-        })
+      signOut: async () => {
+        try {
+          // Call the auth service to clear localStorage and cookies
+          await authService.signOut()
+        } catch (error) {
+          console.error("Error during signOut:", error)
+        } finally {
+          // Always clear the store state
+          set({
+            user: null,
+            isAuthenticated: false,
+            error: null,
+          })
+        }
       },
 
       clearError: () => set({ error: null }),


### PR DESCRIPTION
The Problem
The issue was in the authentication flow where the signOut function in the Zustand auth store was only clearing the local state but not calling the authService.signOut() method. This meant:
The UI would show the user as signed out (state cleared)
But the authentication token remained in localStorage and cookies
The middleware would still see the user as authenticated
So they couldn't access auth pages or truly sign out
The Solution
I've updated the following components to properly handle sign-out:
1. Auth Store (store/auth-store.ts)
Made signOut function async
Added call to authService.signOut() to clear localStorage and cookies
Ensured state is cleared even if the auth service call fails
2. Header Components
Updated handleSignOut functions to be async in both components/header.tsx and components/header/index.tsx
Updated all sign-out button handlers to properly await the async signOut call
Added error handling with user feedback via toast notifications
3. User Actions & Mobile Menu
Updated prop types to reflect async onSignOut function
Modified all click handlers to properly handle async operations